### PR TITLE
make: specify build recipe for drm-info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,5 +22,6 @@ LDFLAGS = -Wall
 
 CFLAGS += `pkg-config --cflags libdrm`
 LDFLAGS += `pkg-config --libs libdrm`
+LDLIBS += `pkg-config --libs libdrm`
 
 all: drm-info


### PR DESCRIPTION
Implicit rules fails to build on Ubuntu:

```
drm-utils$ make
cc -Wall `pkg-config --libs libdrm`  drm-info.o   -o drm-info
/usr/bin/ld: drm-info.o: in function `getCapability':
drm-info.c:(.text+0x30): undefined reference to `drmGetCap'
 ...
```

It seems Ubuntu GCC silently adds --as-needed to the linkage options at a position before the input files and libraries, which then effectively ignores -ldrm when expanded.

Closes: #1